### PR TITLE
is_favorite added

### DIFF
--- a/db/kishan.sql
+++ b/db/kishan.sql
@@ -46,6 +46,7 @@ CREATE TABLE `posts` (
   `description` text NOT NULL,
   `image_id` int(10) UNSIGNED NOT NULL,
   `user_id` int(10) UNSIGNED NOT NULL,
+  `is_favourite` int(10) UNSIGNED NOT NULL,
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   `updated_at` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
   `created_by` int(10) UNSIGNED NOT NULL,


### PR DESCRIPTION
is_favorite added  in posts table..by default its value is '0' when user call /addtofav/postid then you have to update that to '1' and when call /removefromfav/postid then u have to update to '0'.